### PR TITLE
Refactor OSDCloud module: update function exports and add new workflow

### DIFF
--- a/OSDCloud.psd1
+++ b/OSDCloud.psd1
@@ -69,7 +69,7 @@ PowerShellVersion = '5.1'
 # NestedModules = @()
 
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
-FunctionsToExport = 'Get-OSDCloud', 'Start-OSDCloudCore', 'Get-OSDCloudWorkflows','Invoke-WpeinitPSCommand','Invoke-WpeinitPSModuleUpdate',
+FunctionsToExport = 'Get-OSDCloud', 'Start-OSDCloudWorkflow', 'Get-OSDCloudWorkflows','Invoke-WpeinitPSCommand','Invoke-WpeinitPSModuleUpdate',
 'Show-WinpeStartOSK','Show-WinpeStartWindowDeviceInfo','Show-WinpeStartWindowHardware','Show-WinpeStartWindowHardwareErrors',
 'Show-WinpeStartWindowIPConfig','Show-WinpeStartWindowWiFi','Get-OSDCloudModulePath','Get-OSDCloudModuleVersion','Show-WinpeStartPSModuleUpdate'
 

--- a/public/Get-OSDCloud.ps1
+++ b/public/Get-OSDCloud.ps1
@@ -23,14 +23,11 @@ function Get-OSDCloud {
     # Display OSDCloud team information
     Write-Host -ForegroundColor DarkCyan 'OSDCloud Team'
     Write-Host -ForegroundColor DarkGray "David Segura $($PSOSDCloud.links.david)"
-    Write-Host -ForegroundColor DarkGray "Gary Blok $($PSOSDCloud.links.gary)"
     Write-Host -ForegroundColor DarkGray "Michael Escamilla $($PSOSDCloud.links.michael)"
+    Write-Host -ForegroundColor DarkGray "Gary Blok $($PSOSDCloud.links.gary)"
     Write-Host
 
     # Display upcoming events
-    Write-Host -ForegroundColor DarkCyan 'NWSCUG: OSD 2025 Preview'
-    Write-Host -ForegroundColor DarkGray "March 28 2025 $($PSOSDCloud.links.nwscug)"
-    Write-Host
     Write-Host -ForegroundColor DarkCyan 'MMSMOA: OSDCloud and OSDWorkspace'
     Write-Host -ForegroundColor DarkGray "May 5-8 2025 $($PSOSDCloud.links.mmsmoa)"
     Write-Host

--- a/public/Start-OSDCloudWorkflow.ps1
+++ b/public/Start-OSDCloudWorkflow.ps1
@@ -1,4 +1,4 @@
-function Start-OSDCloudCore {
+function Start-OSDCloudWorkflow {
     [CmdletBinding()]
     param ()
     #=================================================


### PR DESCRIPTION
- Updated `FunctionsToExport` in `OSDCloud.psd1` to replace `Start-OSDCloudCore` with `Start-OSDCloudWorkflow`.
- Added new `Start-OSDCloudWorkflow` function in `public/Start-OSDCloudWorkflow.ps1` to manage workflow initialization and execution.
- Restored display of team member Gary Blok in `Get-OSDCloud.ps1`.

These changes enhance the module's functionality by introducing a dedicated workflow management function while maintaining team visibility.