### PR TITLE
Fix architecture check in step-install-bcdboot.ps1 to use correct property name

### DIFF
--- a/private/steps/4-install/step-install-bcdboot.ps1
+++ b/private/steps/4-install/step-install-bcdboot.ps1
@@ -11,7 +11,7 @@ function step-install-bcdboot {
     #=================================================
     #region Main
     # Check what architecture we are using
-    if ($global:OSDCloudWorkflowInit.Architecture -match 'arm64') {
+    if ($global:OSDCloudWorkflowInit.OSArchitecture -match 'ARM64') {
         Write-Host -ForegroundColor DarkGray "[$(Get-Date -format G)][$($MyInvocation.MyCommand.Name)] X:\Windows\System32\bcdboot.exe C:\Windows /c"
         X:\Windows\System32\bcdboot.exe C:\Windows /c
     }


### PR DESCRIPTION
Updated the architecture check in the function `step-install-bcdboot` to reference `$global:OSDCloudWorkflowInit.OSArchitecture` instead of `$global:OSDCloudWorkflowInit.Architecture`. This change ensures that the script correctly identifies the OS architecture as 'ARM64' for proper execution of the bcdboot command.

File modified:
- private/steps/4-install/step-install-bcdboot.ps1

This fix addresses potential issues with architecture detection during the installation process. 🛠️