### PR TITLE
Update module version and enhance module update logic

### DIFF
--- a/OSDCloud.psd1
+++ b/OSDCloud.psd1
@@ -12,7 +12,7 @@
 RootModule = 'OSDCloud.psm1'
 
 # Version number of this module.
-ModuleVersion = '25.4.28.2'
+ModuleVersion = '25.4.28.3'
 
 # Supported PSEditions
 CompatiblePSEditions = 'Desktop'

--- a/public/Invoke-OSDCloudPEStartup.ps1
+++ b/public/Invoke-OSDCloudPEStartup.ps1
@@ -55,7 +55,7 @@ function Invoke-OSDCloudPEStartup {
                     Write-Host "UpdateModule: Unable to reach the PowerShell Gallery. Please check your network connection."
                     return
                 }
-                Use-PEStartupUpdateModule -Name $Value
+                Invoke-PEStartupUpdateModule -Name $Value -Wait
             }
         }
         'Info' {

--- a/public/winpe-startup/Invoke-PEStartupUpdateModule.ps1
+++ b/public/winpe-startup/Invoke-PEStartupUpdateModule.ps1
@@ -25,6 +25,18 @@ function Invoke-PEStartupUpdateModule {
     $Error.Clear()
     Write-Verbose "[$(Get-Date -format G)][$($MyInvocation.MyCommand.Name)] Start"
     #=================================================
+	# Are we on the last version of the module?
+    $InstalledModule = Get-Module -Name $Name -ListAvailable -ErrorAction Ignore | Sort-Object Version -Descending | Select-Object -First 1
+    $GalleryPSModule = Find-Module -Name $Name -ErrorAction Ignore -WarningAction Ignore
+    #=================================================
+    # Install the OSD module if it is not installed or if the version is older than the gallery version
+    if ($GalleryPSModule) {
+        if (($GalleryPSModule.Version -as [version]) -le ($InstalledModule.Version -as [version])) {
+			return
+        }
+    }
+    #=================================================
+	<#
 	# Make sure we are online and can reach the PowerShell Gallery
 	try {
 		$WebRequest = Invoke-WebRequest -Uri "https://www.powershellgallery.com/packages/$Name" -UseBasicParsing -Method Head
@@ -32,6 +44,7 @@ function Invoke-PEStartupUpdateModule {
 	catch {
 		return
     }
+	#>
     #=================================================
 	# https://learn.microsoft.com/en-us/windows-hardware/customize/desktop/unattend/microsoft-windows-setup-runasynchronous
 	# https://learn.microsoft.com/en-us/windows-hardware/customize/desktop/unattend/microsoft-windows-setup-runsynchronous

--- a/public/winpe-startup/Use-PEStartupUpdateModule.ps1
+++ b/public/winpe-startup/Use-PEStartupUpdateModule.ps1
@@ -13,18 +13,9 @@ function Use-PEStartupUpdateModule {
     Write-Host -ForegroundColor DarkCyan "[$((Get-Date).ToString('HH:mm:ss'))] Update PowerShell Module: $Name"
     Write-Host -ForegroundColor DarkCyan "[$((Get-Date).ToString('HH:mm:ss'))] Close this window to cancel (starting in 10 seconds)"
     Start-Sleep -Seconds 10
-
-    $InstalledModule = Get-Module -Name $Name -ListAvailable -ErrorAction Ignore | Sort-Object Version -Descending | Select-Object -First 1
-    $GalleryPSModule = Find-Module -Name $Name -ErrorAction Ignore -WarningAction Ignore
-
-    # Install the OSD module if it is not installed or if the version is older than the gallery version
-    if ($GalleryPSModule) {
-        if (($GalleryPSModule.Version -as [version]) -gt ($InstalledModule.Version -as [version])) {
-            Write-Host -ForegroundColor DarkGray "$Name $($GalleryPSModule.Version) [AllUsers]"
-            Install-Module $Name -Scope AllUsers -Force -SkipPublisherCheck
-            Import-Module $Name -Force
-        }
-    }
+    Write-Host -ForegroundColor DarkGray "$Name $($GalleryPSModule.Version) [AllUsers]"
+    Install-Module $Name -Scope AllUsers -Force -SkipPublisherCheck
+    Import-Module $Name -Force
     #=================================================
     Write-Verbose "[$(Get-Date -format G)][$($MyInvocation.MyCommand.Name)] Done"
     #=================================================


### PR DESCRIPTION
- Updated the module version in OSDCloud.psd1 from '25.4.28.2' to '25.4.28.3'.
- Changed the function call in Invoke-OSDCloudPEStartup.ps1 to use Invoke-PEStartupUpdateModule with the -Wait parameter for better control over the update process.
- Added version checking logic in Invoke-PEStartupUpdateModule.ps1 to ensure the installed module is up-to-date with the PowerShell Gallery version.
- Simplified the update process in Use-PEStartupUpdateModule.ps1 by removing redundant checks and directly installing the module if necessary.

These changes improve the module's update reliability and ensure users are always working with the latest version.