### PR TITLE
Update date formatting in logging messages across multiple scripts

### DIFF
--- a/public/winpe-startup/Invoke-PEStartupPSCommand.ps1
+++ b/public/winpe-startup/Invoke-PEStartupPSCommand.ps1
@@ -69,7 +69,7 @@ $Unattend = @"
 	$Unattend | Out-File -FilePath "$env:Temp\$Command.xml" -Encoding utf8 -Force
 
 	if ($Wait -and $NoExit) {
-		Write-Host -ForegroundColor Yellow "[$((Get-Date).ToString('HH:mm:ss'))] This window may need to be closed to continue the WinPE startup process"
+		Write-Host -ForegroundColor Yellow "[$(Get-Date -format G)] This window may need to be closed to continue the WinPE startup process"
 	}
 
 	if ($Wait) {

--- a/public/winpe-startup/Invoke-PEStartupUpdateModule.ps1
+++ b/public/winpe-startup/Invoke-PEStartupUpdateModule.ps1
@@ -90,7 +90,7 @@ $Unattend = @"
 	$Unattend | Out-File -FilePath "$env:Temp\UpdatePSModule$Name.xml" -Encoding utf8 -Force
 
 	if ($Wait -and $NoExit) {
-		Write-Host -ForegroundColor Yellow "[$((Get-Date).ToString('HH:mm:ss'))] This window may need to be closed to continue the WinPE startup process"
+		Write-Host -ForegroundColor Yellow "[$(Get-Date -format G)] This window may need to be closed to continue the WinPE startup process"
 	}
 	
 	if ($Wait) {

--- a/public/winpe-startup/Use-PEStartupDeviceInfo.ps1
+++ b/public/winpe-startup/Use-PEStartupDeviceInfo.ps1
@@ -6,7 +6,7 @@ function Use-PEStartupDeviceInfo {
     $Error.Clear()
     $host.ui.RawUI.WindowTitle = '[OSDCloud] Device Information'
     #=================================================
-    Write-Host -ForegroundColor DarkCyan "[$((Get-Date).ToString('HH:mm:ss'))] Gathering Device Information"
+    Write-Host -ForegroundColor DarkCyan "[$(Get-Date -format G)] Gathering Device Information"
 
     # Create the log path if it does not already exist
     $LogsPath = "$env:TEMP\osdcloud-logs"
@@ -32,7 +32,7 @@ function Use-PEStartupDeviceInfo {
 
     # OSD Ready
     $OSDVersion = (Get-Module -Name OSD -ListAvailable | Sort-Object Version -Descending | Select-Object -First 1).Version
-    Write-Host -ForegroundColor DarkCyan "[$((Get-Date).ToString('HH:mm:ss'))] OSD PowerShell Module $OSDVersion Ready"
+    Write-Host -ForegroundColor DarkCyan "[$(Get-Date -format G)] OSD PowerShell Module $OSDVersion Ready"
 
     # Device Details
     Write-Host ''
@@ -52,7 +52,7 @@ function Use-PEStartupDeviceInfo {
     $TotalMemory = $([math]::Round($Win32ComputerSystem.TotalPhysicalMemory / 1024 / 1024 / 1024))
     Write-Host -ForegroundColor DarkGray 'Memory:' $TotalMemory 'GB'
     if ($TotalMemory -lt 6) {
-        Write-Warning "[$((Get-Date).ToString('HH:mm:ss'))] OSDCloud WinPE requires at least 6 GB of memory to function properly. Errors are expected."
+        Write-Warning "[$(Get-Date -format G)] OSDCloud WinPE requires at least 6 GB of memory to function properly. Errors are expected."
     }
 
     # Win32_DiskDrive

--- a/public/winpe-startup/Use-PEStartupHardware.ps1
+++ b/public/winpe-startup/Use-PEStartupHardware.ps1
@@ -9,7 +9,7 @@ function Use-PEStartupHardware {
     $Results = Get-CimInstance -ClassName Win32_PnPEntity | Select-Object Status, DeviceID, Name, Manufacturer, PNPClass, Service | Sort-Object DeviceID
 
     if ($Results) {
-        Write-Host -ForegroundColor DarkCyan "[$((Get-Date).ToString('HH:mm:ss'))] Get-CimInstance Win32_PnPEntity Hardware Devices"
+        Write-Host -ForegroundColor DarkCyan "[$(Get-Date -format G)] Get-CimInstance Win32_PnPEntity Hardware Devices"
         Write-Output $Results | Format-Table -AutoSize
     }
     else {

--- a/public/winpe-startup/Use-PEStartupHardwareErrors.ps1
+++ b/public/winpe-startup/Use-PEStartupHardwareErrors.ps1
@@ -9,8 +9,8 @@ function Use-PEStartupHardwareErrors {
     $Results = Get-CimInstance -ClassName Win32_PnPEntity | Select-Object Status, DeviceID, Name, Manufacturer, PNPClass, Service | Where-Object Status -ne 'OK' | Sort-Object Status, DeviceID
 
     if ($Results) {
-        Write-Host -ForegroundColor DarkCyan "[$((Get-Date).ToString('HH:mm:ss'))] Get-CimInstance Win32_PnPEntity Hardware Devices with Issues"
-        Write-Host -ForegroundColor DarkCyan "[$((Get-Date).ToString('HH:mm:ss'))] This window will automatically close in 5 seconds"
+        Write-Host -ForegroundColor DarkCyan "[$(Get-Date -format G)] Get-CimInstance Win32_PnPEntity Hardware Devices with Issues"
+        Write-Host -ForegroundColor DarkCyan "[$(Get-Date -format G)] This window will automatically close in 5 seconds"
         Write-Output $Results | Format-Table -AutoSize
         Start-Sleep -Seconds 5
     }

--- a/public/winpe-startup/Use-PEStartupIpconfig.ps1
+++ b/public/winpe-startup/Use-PEStartupIpconfig.ps1
@@ -6,7 +6,7 @@ function Use-PEStartupIpconfig {
     $Error.Clear()
     $host.ui.RawUI.WindowTitle = '[OSDCloud] IPConfig - Network Configuration'
     #=================================================
-    Write-Host -ForegroundColor DarkCyan "[$((Get-Date).ToString('HH:mm:ss'))] ipconfig /all"
+    Write-Host -ForegroundColor DarkCyan "[$(Get-Date -format G)] ipconfig /all"
     ipconfig /all
     #=================================================
     Write-Verbose "[$(Get-Date -format G)][$($MyInvocation.MyCommand.Name)] Done"

--- a/public/winpe-startup/Use-PEStartupUpdateModule.ps1
+++ b/public/winpe-startup/Use-PEStartupUpdateModule.ps1
@@ -10,10 +10,10 @@ function Use-PEStartupUpdateModule {
     Write-Verbose "[$(Get-Date -format G)][$($MyInvocation.MyCommand.Name)] Start"
     $host.ui.RawUI.WindowTitle = "[OSDCloud] Update PowerShell Module: $Name (close this window to cancel)"
     #=================================================
-    Write-Host -ForegroundColor DarkCyan "[$((Get-Date).ToString('HH:mm:ss'))] Update PowerShell Module: $Name"
-    Write-Host -ForegroundColor DarkCyan "[$((Get-Date).ToString('HH:mm:ss'))] Close this window to cancel (starting in 10 seconds)"
+    Write-Host -ForegroundColor DarkCyan "[$(Get-Date -format G)] Update PowerShell Module: $Name"
+    Write-Host -ForegroundColor DarkCyan "[$(Get-Date -format G)] Close this window to cancel (starting in 10 seconds)"
     Start-Sleep -Seconds 10
-    Write-Host -ForegroundColor DarkGray "$Name $($GalleryPSModule.Version) [AllUsers]"
+    Write-Host -ForegroundColor DarkGray "[$(Get-Date -format G)] $Name $($GalleryPSModule.Version) [AllUsers]"
     Install-Module $Name -Scope AllUsers -Force -SkipPublisherCheck
     Import-Module $Name -Force
     #=================================================

--- a/public/winpe-startup/Use-PEStartupWiFi.ps1
+++ b/public/winpe-startup/Use-PEStartupWiFi.ps1
@@ -9,24 +9,24 @@ function Use-PEStartupWiFi {
     if (Test-Path "$env:SystemRoot\System32\dmcmnutils.dll") {
         if ($WirelessConnect) {
             #TODO - Enable functionality for WirelessConnect.exe
-            Write-Host -ForegroundColor DarkCyan "[$((Get-Date).ToString('HH:mm:ss'))] Starting WirelessConnect.exe"
+            Write-Host -ForegroundColor DarkCyan "[$(Get-Date -format G)] Starting WirelessConnect.exe"
             Start-Process PowerShell -ArgumentList 'Start-WinREWiFi -WirelessConnect' -Wait
         }
         elseif ($WifiProfile) {
             #TODO - Enable functionality for WifiProfile
-            Write-Host -ForegroundColor DarkCyan "[$((Get-Date).ToString('HH:mm:ss'))] Starting WiFi Profile"
+            Write-Host -ForegroundColor DarkCyan "[$(Get-Date -format G)] Starting WiFi Profile"
             $Global:WifiProfile = Get-PSDrive -PSProvider FileSystem | Where-Object { $_.Name -ne 'C' } | ForEach-Object {
                 Get-ChildItem "$($_.Root)OSDCloud\Config\Scripts" -Include "WiFiProfile.xml" -File -Recurse -Force -ErrorAction Ignore
             }
             Start-Process PowerShell -ArgumentList "Start-WinREWiFi -WifiProfile `"$Global:WifiProfile`"" -Wait
         }
         else {
-            Write-Host -ForegroundColor DarkCyan "[$((Get-Date).ToString('HH:mm:ss'))] Starting Wi-Fi"
+            Write-Host -ForegroundColor DarkCyan "[$(Get-Date -format G)] Starting Wi-Fi"
             Start-Process PowerShell Start-WinREWiFi -Wait
         }
     }
 
-    Write-Host -ForegroundColor DarkCyan "[$((Get-Date).ToString('HH:mm:ss'))] Initialize Network Connections"
+    Write-Host -ForegroundColor DarkCyan "[$(Get-Date -format G)] Initialize Network Connections"
     $timeout = 0
     while ($timeout -lt 20) {
         Start-Sleep -Seconds $timeout
@@ -34,15 +34,15 @@ function Use-PEStartupWiFi {
 
         $IP = Test-Connection -ComputerName $(HOSTNAME) -Count 1 | Select-Object -ExpandProperty IPV4Address
         if ($null -eq $IP) {
-            Write-Host -ForegroundColor DarkGray "[$((Get-Date).ToString('HH:mm:ss'))] Network adapter error. This should not happen!"
+            Write-Host -ForegroundColor DarkGray "[$(Get-Date -format G)] Network adapter error. This should not happen!"
         }
         elseif ($IP.IPAddressToString.StartsWith('169.254') -or $IP.IPAddressToString.Equals('127.0.0.1')) {
-            Write-Host -ForegroundColor DarkGray "[$((Get-Date).ToString('HH:mm:ss'))] IP address not yet assigned by DHCP. Trying to get a new DHCP lease."
+            Write-Host -ForegroundColor DarkGray "[$(Get-Date -format G)] IP address not yet assigned by DHCP. Trying to get a new DHCP lease."
             ipconfig /release | Out-Null
             ipconfig /renew | Out-Null
         }
         else {
-            Write-Host -ForegroundColor DarkGray "[$((Get-Date).ToString('HH:mm:ss'))] Network configuration renewed with IP: $($IP.IPAddressToString)"
+            Write-Host -ForegroundColor DarkGray "[$(Get-Date -format G)] Network configuration renewed with IP: $($IP.IPAddressToString)"
             break
         }
     }


### PR DESCRIPTION
- Changed date formatting from 'HH:mm:ss' to a more readable format 'G' in the following files:
  - Invoke-PEStartupPSCommand.ps1
  - Invoke-PEStartupUpdateModule.ps1
  - Use-PEStartupDeviceInfo.ps1
  - Use-PEStartupHardware.ps1
  - Use-PEStartupHardwareErrors.ps1
  - Use-PEStartupIpconfig.ps1
  - Use-PEStartupWiFi.ps1

This update enhances the clarity of log messages by providing a more user-friendly date and time format, improving the overall user experience during the WinPE startup process.