### PR TITLE
fix: Update module version and improve SHA verification logic

### DIFF
--- a/OSDCloud.psd1
+++ b/OSDCloud.psd1
@@ -12,7 +12,7 @@
 RootModule = 'OSDCloud.psm1'
 
 # Version number of this module.
-ModuleVersion = '25.9.30.1'
+ModuleVersion = '25.9.30.2'
 
 # Supported PSEditions
 CompatiblePSEditions = 'Desktop'

--- a/private/steps/4-install/step-install-downloadwindowsimage.ps1
+++ b/private/steps/4-install/step-install-downloadwindowsimage.ps1
@@ -75,7 +75,7 @@ function step-install-downloadwindowsimage {
         Write-Host -ForegroundColor DarkGray "[$(Get-Date -format G)] Microsoft Verified ESD SHA1: $($OperatingSystemObject.Sha1)"
         Write-Host -ForegroundColor DarkGray "[$(Get-Date -format G)] Downloaded ESD SHA1: $FileHash"
 
-        if ($OperatingSystemObject.Sha1 -ne $FileHash) {
+        if ($OperatingSystemObject.Sha1 -notmatch $FileHash) {
             Write-Warning "[$(Get-Date -format G)] Unable to deploy this Operating System."
             Write-Warning "[$(Get-Date -format G)] Downloaded ESD SHA1 does not match the verified Microsoft ESD SHA1."
             Write-Warning 'Press Ctrl+C to cancel OSDCloud'
@@ -90,7 +90,7 @@ function step-install-downloadwindowsimage {
         Write-Host -ForegroundColor DarkGray "[$(Get-Date -format G)] Microsoft Verified ESD SHA256: $($OperatingSystemObject.Sha256)"
         Write-Host -ForegroundColor DarkGray "[$(Get-Date -format G)] Downloaded ESD SHA256: $FileHash"
 
-        if ($OperatingSystemObject.V -ne $FileHash) {
+        if ($OperatingSystemObject.V -notmatch $FileHash) {
             Write-Warning "[$(Get-Date -format G)] Unable to deploy this Operating System."
             Write-Warning "[$(Get-Date -format G)] Downloaded ESD SHA256 does not match the verified Microsoft ESD SHA256."
             Write-Warning 'Press Ctrl+C to cancel OSDCloud'


### PR DESCRIPTION
- Updated ModuleVersion in OSDCloud.psd1 from '25.9.30.1' to '25.9.30.2'.
- Modified SHA verification conditions in step-install-downloadwindowsimage.ps1 to use -notmatch for better accuracy in comparing hashes.

These changes enhance the module's versioning and ensure more reliable verification of downloaded ESD files.