### PR TITLE
fix: Update module version and correct SHA256 verification logic

### DIFF
--- a/OSDCloud.psd1
+++ b/OSDCloud.psd1
@@ -12,7 +12,7 @@
 RootModule = 'OSDCloud.psm1'
 
 # Version number of this module.
-ModuleVersion = '25.9.30.2'
+ModuleVersion = '25.9.30.3'
 
 # Supported PSEditions
 CompatiblePSEditions = 'Desktop'

--- a/private/steps/4-install/step-install-downloadwindowsimage.ps1
+++ b/private/steps/4-install/step-install-downloadwindowsimage.ps1
@@ -90,7 +90,7 @@ function step-install-downloadwindowsimage {
         Write-Host -ForegroundColor DarkGray "[$(Get-Date -format G)] Microsoft Verified ESD SHA256: $($OperatingSystemObject.Sha256)"
         Write-Host -ForegroundColor DarkGray "[$(Get-Date -format G)] Downloaded ESD SHA256: $FileHash"
 
-        if ($OperatingSystemObject.V -notmatch $FileHash) {
+        if ($OperatingSystemObject.Sha256 -notmatch $FileHash) {
             Write-Warning "[$(Get-Date -format G)] Unable to deploy this Operating System."
             Write-Warning "[$(Get-Date -format G)] Downloaded ESD SHA256 does not match the verified Microsoft ESD SHA256."
             Write-Warning 'Press Ctrl+C to cancel OSDCloud'


### PR DESCRIPTION
- Updated ModuleVersion in OSDCloud.psd1 from '25.9.30.2' to '25.9.30.3'.
- Changed SHA256 verification condition in step-install-downloadwindowsimage.ps1 to use the correct property ($OperatingSystemObject.Sha256) instead of ($OperatingSystemObject.V).

These changes ensure the module version is accurate and the SHA256 verification works as intended, enhancing the reliability of the deployment process.