### PR TITLE
Hydrate missing SetupSpecialize.cmd file

### DIFF
--- a/private/steps/5-drivers/step-drivers-driverpack.ps1
+++ b/private/steps/5-drivers/step-drivers-driverpack.ps1
@@ -276,6 +276,9 @@ function step-drivers-driverpack {
     #   Lenovo
     #=================================================
     if (($OutFileObject.Extension -eq '.exe') -and ($OutFileObject.VersionInfo.FileDescription -match 'Lenovo')) {
+        if (-not (Test-Path $SetupSpecializeCmd)) {
+            New-Item -Path $SetupSpecializeCmd -ItemType File -Force -ErrorAction Ignore | Out-Null
+        }
         Write-Host -ForegroundColor DarkGray "FileDescription: $($OutFileObject.VersionInfo.FileDescription)"
         Write-Host -ForegroundColor DarkGray "ProductVersion: $($OutFileObject.VersionInfo.ProductVersion)"
         Write-Host -ForegroundColor DarkGray "[$(Get-Date -format G)] Adding Lenovo DriverPack to $SetupSpecializeCmd"


### PR DESCRIPTION
`$Content | Out-File -FilePath $SetupSpecializeCmd -Append -Encoding ascii -Width 2000 -Force` throws an error because the `C:\Windows\Temp\osdcloud` directory doesn't exist.

The `-Force` parameter doesn't create the missing directory structure.

Hydrating the `SetupSpecialize.cmd` file with `New-Item -Path $SetupSpecializeCmd -ItemType File -Force` does create the directory structure.